### PR TITLE
Unicode support for string directives

### DIFF
--- a/rars/assembler/Assembler.java
+++ b/rars/assembler/Assembler.java
@@ -1034,6 +1034,7 @@ public class Assembler {
                 char theChar;
                 for (int j = 1; j < quote.length() - 1; j++) {
                     theChar = quote.charAt(j);
+                    String strOfChar = "";
                     if (theChar == '\\') {
                         theChar = quote.charAt(++j);
                         switch (theChar) {
@@ -1064,14 +1065,24 @@ public class Assembler {
                             case '0':
                                 theChar = '\0';
                                 break;
+                            case 'u':
+                                String codePoint = quote.substring(j+1, j+5); //get the UTF-8 codepoint following that follows the unicode escape sequence
+                                try{
+                                    theChar = Character.toChars(Integer.parseInt(codePoint, 16))[0]; //converts the codepoint to single character
+                                } catch(NumberFormatException e){
+                                    errors.add(new ErrorMessage(token.getSourceProgram(), token
+                                        .getSourceLine(), token.getStartPos(), "illegal unicode escape: \"\\u" + codePoint + "\""));
+                                }
+                                j = j + 4; //skip past the codepoint for next iteration
+                                break;
+
                             // Not implemented: \ n = octal character (n is number)
                             // \ x n = hex character (n is number)
-                            // \ u n = unicode character (n is number)
                             // There are of course no spaces in these escape
                             // codes...
                         }
                     }
-                    String strOfChar = String.valueOf(theChar);
+                    strOfChar = String.valueOf(theChar); //gets the string representation of the char for use with getBytes
                     try{
                         byte[] bytesOfChar = strOfChar.getBytes("UTF-8");
                         int lenOfArray = bytesOfChar.length;
@@ -1087,6 +1098,7 @@ public class Assembler {
                             this.dataAddress.increment(DataTypes.CHAR_SIZE);
                         }
                     } catch (UnsupportedEncodingException e) {
+                        //happens when the getBytes method uses an encoding type that is not supported by the JVM
                         System.out.println("Unsupported character set");
                     }
                 }

--- a/rars/assembler/Assembler.java
+++ b/rars/assembler/Assembler.java
@@ -12,6 +12,8 @@ import rars.util.SystemIO;
 import java.util.ArrayList;
 import java.util.Collections;
 
+import java.io.UnsupportedEncodingException;
+
 /*
  Copyright (c) 2003-2012,  Pete Sanderson and Kenneth Vollmar
 
@@ -1069,15 +1071,24 @@ public class Assembler {
                             // codes...
                         }
                     }
-                    try {
-                        Globals.memory.set(this.dataAddress.get(), (int) theChar,
-                                DataTypes.CHAR_SIZE);
-                    } catch (AddressErrorException e) {
-                        errors.add(new ErrorMessage(token.getSourceProgram(), token
-                                .getSourceLine(), token.getStartPos(), "\""
-                                + this.dataAddress.get() + "\" is not a valid data segment address"));
+                    String strOfChar = String.valueOf(theChar);
+                    try{
+                        byte[] bytesOfChar = strOfChar.getBytes("UTF-8");
+                        int lenOfArray = bytesOfChar.length;
+                        for (int k = 0; k < lenOfArray; k++){
+                            try {
+                                Globals.memory.set(this.dataAddress.get(), bytesOfChar[k],
+                                        DataTypes.CHAR_SIZE);
+                            } catch (AddressErrorException e) {
+                                errors.add(new ErrorMessage(token.getSourceProgram(), token
+                                        .getSourceLine(), token.getStartPos(), "\""
+                                        + this.dataAddress.get() + "\" is not a valid data segment address"));
+                            }
+                            this.dataAddress.increment(DataTypes.CHAR_SIZE);
+                        }
+                    } catch (UnsupportedEncodingException e) {
+                        System.out.println("Unsupported character set");
                     }
-                    this.dataAddress.increment(DataTypes.CHAR_SIZE);
                 }
                 if (direct == Directives.ASCIZ || direct == Directives.STRING) {
                     try {

--- a/rars/riscv/syscalls/NullString.java
+++ b/rars/riscv/syscalls/NullString.java
@@ -72,7 +72,7 @@ public class NullString {
 
         int size = utf8BytesList.size();
         byte[] utf8Bytes = new byte[size];
-        for (int i=0; i<size; i++){
+        for (int i=0; i < (size - 1); i++){ //size - 1 so we dont include the null terminator in the utf8Bytes array
             utf8Bytes[i] = utf8BytesList.get(i);
         }
 

--- a/test/success.s
+++ b/test/success.s
@@ -1,7 +1,7 @@
 .globl main
 .text
 main:
-	# Simple test to confirm the success code workds
+	# Simple test to confirm the success code works
 	li a0, 42 
 	li a7, 93
 	ecall


### PR DESCRIPTION
Noticed that the original pull request which added unicode support for the printstring syscall appears to have broken the open syscall. When stepping through the example File I/O code, which is provided in the syscalls tab of the f1 help in rars, the open file syscall returns -1 in a0 indicating that the file was not opened successfully. Because this problem appears to have started with the modifications in the original pull request they remain in this update. @rmnattas and I narrowed the issue down to the line 447 in the following:

https://github.com/TaylorZowtuk/rars/blob/d057f7776fe7ea4bcbd8f756dea45a6b274511b7/rars/util/SystemIO.java#L415-L456

From there we noticed that if we replace `filename` with `"testout.txt"` the file is created/opened successfully and will then write to the file successfully. We see that openfile is called in:

https://github.com/TaylorZowtuk/rars/blob/d057f7776fe7ea4bcbd8f756dea45a6b274511b7/rars/riscv/syscalls/SyscallOpen.java#L45-L49

which uses the `NullString.get()` method that was modified in the original pull request. We don't think its an issue with the utf-8 encoding because the filename bytes are loaded correctly in memory and `FileOutputStream()` is able to create a file with a utf-8 encoded name in a java simulator. As of right now we are still looking into this issue but wanted to update with these new changes. Any advice into what this problem may be would be appreciated.
